### PR TITLE
Glob pattern expansion and file lists

### DIFF
--- a/tasks/grunt-audiosprite.js
+++ b/tasks/grunt-audiosprite.js
@@ -12,7 +12,7 @@ module.exports = function(grunt)
 		function() 
 		{
 			var data = this.data,
-				input = grunt.file.expand(data.input)
+				input = data.input && grunt.file.expand(data.input),
 				output = data.output || "output",
 				ogg_to_oga = data.ogg_to_oga || true,
 				cwd = data.cwd || process.cwd(),

--- a/tasks/grunt-audiosprite.js
+++ b/tasks/grunt-audiosprite.js
@@ -12,6 +12,7 @@ module.exports = function(grunt)
 		function() 
 		{
 			var data = this.data,
+				input = grunt.file.expand(data.input)
 				output = data.output || "output",
 				ogg_to_oga = data.ogg_to_oga || true,
 				cwd = data.cwd || process.cwd(),
@@ -46,6 +47,7 @@ module.exports = function(grunt)
 				'cwd',
 				'callback',
 				'files',
+				'input',
 				'ogg_to_oga'
 			];
 
@@ -68,6 +70,7 @@ module.exports = function(grunt)
 			});
 
 			// Check for files, which is required!
+			files = input || files
 			if (!files)
 			{
 				log.error("Source files audio must be defined for the audiosprite");


### PR DESCRIPTION
Thanks for this plugin.

I discovered that if I set _files_ to be a list, e.g. files: ["one.wav", "two.wav"], Grunt complains. It seems to do some special processing on the _files_ field, expecting a _src_ inside it. Also, on Windows, setting _files_ to a wildcard string doesn't work. (File not found with a \* in it.)

I've added an alternative _input_ field, which is processed by grunt.file.expand, and this fixes both of those problems. For backwards compatibility, the original _files_ field is still supported with the original behaviour.

So now we can have stuff like...

```
audiosprite : {
    all : {
        // All wav files except music.wav...
        input: ["audio/*.wav", "!audio/music.wav"],
        ...
```

It would be great if you could pull this into your version.
